### PR TITLE
feat(tsconfig-common): Remove deprecated "newLine" flag

### DIFF
--- a/packages/tsconfig-common/tsconfig.json
+++ b/packages/tsconfig-common/tsconfig.json
@@ -11,7 +11,6 @@
     "lib": ["es2023"],
     "module": "nodenext",
     "moduleResolution": "node16",
-    "newLine": "lf",
     "noEmitOnError": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,


### PR DESCRIPTION
The newLine flag got deprecated and will error in TS 6.0: https://github.com/microsoft/TypeScript/issues/51909

See also here: https://devblogs.microsoft.com/typescript/announcing-typescript-5-5-beta/#disabling-features-deprecated-in-typescript-50