### PR TITLE
fix(eslint-config): replace abandoned sort-keys-fix with perfectionist

### DIFF
--- a/packages/eslint-config/eslint.config.mjs
+++ b/packages/eslint-config/eslint.config.mjs
@@ -77,6 +77,7 @@ export default defineConfig([
       curly: 'error',
       'dot-notation': 'off',
       'max-depth': ['warn', 4],
+      'multiline-comment-style': ['error', 'starred-block'],
       'no-cond-assign': 'error',
       'no-console': 'off',
       'no-const-assign': 'error',
@@ -108,9 +109,11 @@ export default defineConfig([
         },
       ],
 
-      // We use a plugin instead of ESLint's core `sort-keys` rule because that rule is
-      // frozen and provides no autofix.
-      // https://eslint.org/docs/latest/rules/sort-keys#require-object-keys-to-be-sorted-sort-keys
+      /*
+       * We use a plugin instead of ESLint's core `sort-keys` rule because that rule is
+       * frozen and provides no autofix.
+       * https://eslint.org/docs/latest/rules/sort-keys#require-object-keys-to-be-sorted-sort-keys
+       */
       'perfectionist/sort-objects': [
         'warn',
         {

--- a/packages/eslint-config/eslint.config.mjs
+++ b/packages/eslint-config/eslint.config.mjs
@@ -1,4 +1,5 @@
 import {defineConfig} from 'eslint/config';
+import stylistic from '@stylistic/eslint-plugin';
 import typescriptEslint from '@typescript-eslint/eslint-plugin';
 import prettier from 'eslint-plugin-prettier';
 import perfectionist from 'eslint-plugin-perfectionist';
@@ -23,6 +24,7 @@ export default defineConfig([
     // https://eslint.org/docs/latest/use/configure/configuration-files#configuration-naming-conventions
     name: '@tstv/eslint-config',
     plugins: {
+      '@stylistic': stylistic,
       '@typescript-eslint': typescriptEslint,
       perfectionist,
       prettier,
@@ -48,6 +50,7 @@ export default defineConfig([
     },
 
     rules: {
+      '@stylistic/multiline-comment-style': ['error', 'starred-block'],
       '@typescript-eslint/array-type': 'error',
       '@typescript-eslint/consistent-type-assertions': 'error',
       '@typescript-eslint/consistent-type-imports': 'error',
@@ -77,7 +80,6 @@ export default defineConfig([
       curly: 'error',
       'dot-notation': 'off',
       'max-depth': ['warn', 4],
-      'multiline-comment-style': ['error', 'starred-block'],
       'no-cond-assign': 'error',
       'no-console': 'off',
       'no-const-assign': 'error',

--- a/packages/eslint-config/eslint.config.mjs
+++ b/packages/eslint-config/eslint.config.mjs
@@ -108,6 +108,9 @@ export default defineConfig([
         },
       ],
 
+      // We use a plugin instead of ESLint's core `sort-keys` rule because that rule is
+      // frozen and provides no autofix.
+      // https://eslint.org/docs/latest/rules/sort-keys#require-object-keys-to-be-sorted-sort-keys
       'perfectionist/sort-objects': [
         'warn',
         {

--- a/packages/eslint-config/eslint.config.mjs
+++ b/packages/eslint-config/eslint.config.mjs
@@ -1,7 +1,7 @@
 import {defineConfig} from 'eslint/config';
 import typescriptEslint from '@typescript-eslint/eslint-plugin';
 import prettier from 'eslint-plugin-prettier';
-import sortKeysFix from 'eslint-plugin-sort-keys-fix';
+import perfectionist from 'eslint-plugin-perfectionist';
 import globals from 'globals';
 import tsParser from '@typescript-eslint/parser';
 import path from 'node:path';
@@ -24,8 +24,8 @@ export default defineConfig([
     name: '@tstv/eslint-config',
     plugins: {
       '@typescript-eslint': typescriptEslint,
+      perfectionist,
       prettier,
-      'sort-keys-fix': sortKeysFix,
     },
 
     languageOptions: {
@@ -108,21 +108,23 @@ export default defineConfig([
         },
       ],
 
+      // Replaces the abandoned eslint-plugin-sort-keys-fix (last published 2023, crashes
+      // under ESLint 10 because it calls the removed context.getSourceCode()). Mirrors the
+      // previous behavior: natural, case-sensitive, ascending object-key order, autofixable.
+      'perfectionist/sort-objects': [
+        'warn',
+        {
+          ignoreCase: false,
+          order: 'asc',
+          type: 'natural',
+        },
+      ],
+
       'prefer-arrow-callback': 'error',
       'prefer-const': 'error',
       'prefer-promise-reject-errors': 'error',
       'prettier/prettier': 'error',
       'sort-imports': 'off',
-
-      'sort-keys-fix/sort-keys-fix': [
-        'warn',
-        'asc',
-        {
-          caseSensitive: true,
-          natural: true,
-        },
-      ],
-
       'sort-vars': 'error',
       'space-in-parens': 'error',
       strict: ['error', 'global'],

--- a/packages/eslint-config/eslint.config.mjs
+++ b/packages/eslint-config/eslint.config.mjs
@@ -13,33 +13,22 @@ import {FlatCompat} from '@eslint/eslintrc';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({
+  allConfig: js.configs.all,
   baseDirectory: __dirname,
   recommendedConfig: js.configs.recommended,
-  allConfig: js.configs.all,
 });
 
 export default defineConfig([
   {
     extends: compat.extends('prettier'),
-    // https://eslint.org/docs/latest/use/configure/configuration-files#configuration-naming-conventions
-    name: '@tstv/eslint-config',
-    plugins: {
-      '@stylistic': stylistic,
-      '@typescript-eslint': typescriptEslint,
-      perfectionist,
-      prettier,
-    },
-
     languageOptions: {
+      ecmaVersion: 8,
+
       globals: {
         ...globals.browser,
         ...globals.node,
       },
-
       parser: tsParser,
-      ecmaVersion: 8,
-      sourceType: 'module',
-
       parserOptions: {
         ecmaFeatures: {
           jsx: true,
@@ -47,6 +36,17 @@ export default defineConfig([
         // https://typescript-eslint.io/blog/parser-options-project-true/
         project: true,
       },
+
+      sourceType: 'module',
+    },
+    // https://eslint.org/docs/latest/use/configure/configuration-files#configuration-naming-conventions
+    name: '@tstv/eslint-config',
+
+    plugins: {
+      '@stylistic': stylistic,
+      '@typescript-eslint': typescriptEslint,
+      perfectionist,
+      prettier,
     },
 
     rules: {

--- a/packages/eslint-config/eslint.config.mjs
+++ b/packages/eslint-config/eslint.config.mjs
@@ -108,9 +108,6 @@ export default defineConfig([
         },
       ],
 
-      // Replaces the abandoned eslint-plugin-sort-keys-fix (last published 2023, crashes
-      // under ESLint 10 because it calls the removed context.getSourceCode()). Mirrors the
-      // previous behavior: natural, case-sensitive, ascending object-key order, autofixable.
       'perfectionist/sort-objects': [
         'warn',
         {

--- a/packages/eslint-config/lint.config.mjs
+++ b/packages/eslint-config/lint.config.mjs
@@ -33,4 +33,12 @@ export default defineConfig([
       'prettier/prettier': 'error',
     },
   },
+  {
+    /*
+     * Intentionally-broken fixtures live under test/ and must be excluded from the normal
+     * lint run. The `test:invalid` script lints them explicitly (with --no-ignore) and
+     * asserts that linting fails, proving the rules actually reject violations.
+     */
+    ignores: ['test/**'],
+  },
 ]);

--- a/packages/eslint-config/lint.config.mjs
+++ b/packages/eslint-config/lint.config.mjs
@@ -1,0 +1,36 @@
+import {defineConfig} from 'eslint/config';
+import stylistic from '@stylistic/eslint-plugin';
+import perfectionist from 'eslint-plugin-perfectionist';
+import prettier from 'eslint-plugin-prettier';
+import prettierConfig from 'eslint-config-prettier';
+import eslintConfig from './eslint.config.mjs';
+
+/*
+ * Dogfood the shared config on this package's own code. The published `eslint.config.mjs`
+ * intentionally ships no `files` glob (each consumer adds their own), so this wrapper adds
+ * one and is used by the `test`/`fix` scripts to lint the repo.
+ */
+export default defineConfig([
+  {
+    extends: [eslintConfig],
+    files: ['**/*.ts'],
+  },
+  {
+    /*
+     * The flat-config files are not part of a TypeScript project, so the type-aware rules
+     * cannot run on them. Lint them for style only: comment style, key order, and formatting.
+     */
+    extends: [prettierConfig],
+    files: ['**/*.mjs'],
+    plugins: {
+      '@stylistic': stylistic,
+      perfectionist,
+      prettier,
+    },
+    rules: {
+      '@stylistic/multiline-comment-style': ['error', 'starred-block'],
+      'perfectionist/sort-objects': ['warn', {ignoreCase: false, order: 'asc', type: 'natural'}],
+      'prettier/prettier': 'error',
+    },
+  },
+]);

--- a/packages/eslint-config/lint.config.mjs
+++ b/packages/eslint-config/lint.config.mjs
@@ -1,8 +1,5 @@
 import {defineConfig} from 'eslint/config';
-import stylistic from '@stylistic/eslint-plugin';
-import perfectionist from 'eslint-plugin-perfectionist';
-import prettier from 'eslint-plugin-prettier';
-import prettierConfig from 'eslint-config-prettier';
+import typescriptEslint from '@typescript-eslint/eslint-plugin';
 import eslintConfig from './eslint.config.mjs';
 
 /*
@@ -18,20 +15,11 @@ export default defineConfig([
   {
     /*
      * The flat-config files are not part of a TypeScript project, so the type-aware rules
-     * cannot run on them. Lint them for style only: comment style, key order, and formatting.
+     * cannot run on them. Inherit the shared config and switch off only the type-checked
+     * rules (and project-based parsing) so the style rules still apply without duplicating them.
      */
-    extends: [prettierConfig],
+    extends: [eslintConfig, typescriptEslint.configs['flat/disable-type-checked']],
     files: ['**/*.mjs'],
-    plugins: {
-      '@stylistic': stylistic,
-      perfectionist,
-      prettier,
-    },
-    rules: {
-      '@stylistic/multiline-comment-style': ['error', 'starred-block'],
-      'perfectionist/sort-objects': ['warn', {ignoreCase: false, order: 'asc', type: 'natural'}],
-      'prettier/prettier': 'error',
-    },
   },
   {
     /*

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -5,8 +5,8 @@
     "@typescript-eslint/eslint-plugin": "^8.56.1",
     "@typescript-eslint/parser": "^8.56.1",
     "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-perfectionist": "^5.9.0",
     "eslint-plugin-prettier": "^5.5.5",
-    "eslint-plugin-sort-keys-fix": "^1.1.2",
     "globals": "^17.4.0"
   },
   "description": "Shareable ESLint Config",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -39,8 +39,10 @@
     "build": "exit 0",
     "clean": "exit 0",
     "dist": "yarn clean && yarn build",
-    "fix": "npm run test -- --fix",
-    "test": "eslint -c ./lint.config.mjs ."
+    "fix": "npm run test:valid -- --fix",
+    "test": "npm run test:valid && npm run test:invalid",
+    "test:invalid": "! eslint -c ./lint.config.mjs --no-ignore test/invalid",
+    "test:valid": "eslint -c ./lint.config.mjs ."
   },
   "version": "4.1.2"
 }

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "@eslint/eslintrc": "^3.3.4",
     "@eslint/js": "^10.0.1",
+    "@stylistic/eslint-plugin": "^5.10.0",
     "@typescript-eslint/eslint-plugin": "^8.56.1",
     "@typescript-eslint/parser": "^8.56.1",
     "eslint-config-prettier": "^10.1.8",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -40,7 +40,7 @@
     "clean": "exit 0",
     "dist": "yarn clean && yarn build",
     "fix": "npm run test -- --fix",
-    "test": "eslint -c ./eslint.config.mjs src/typescript.ts"
+    "test": "eslint -c ./lint.config.mjs ."
   },
   "version": "4.1.2"
 }

--- a/packages/eslint-config/test/invalid/multiline-comment.mjs
+++ b/packages/eslint-config/test/invalid/multiline-comment.mjs
@@ -1,0 +1,3 @@
+// first line
+// second line
+export const x = 1;

--- a/packages/eslint-config/test/invalid/multiline-comment.ts
+++ b/packages/eslint-config/test/invalid/multiline-comment.ts
@@ -1,0 +1,3 @@
+// first line
+// second line
+export const value = 1;

--- a/yarn.lock
+++ b/yarn.lock
@@ -882,6 +882,15 @@
     "@typescript-eslint/types" "^8.59.1"
     debug "^4.4.3"
 
+"@typescript-eslint/project-service@8.59.4":
+  version "8.59.4"
+  resolved "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.4.tgz#5830535a0e7a3ae806e2669964f47a74c4bc6b0e"
+  integrity sha512-Ly00Vu4oAacfDeHp2Zg85ioNG6l8HG+tN1D7J+xTHSxu9y0awYKJ2zH1rFBn8ZSfuGK+7FxK3Cgl3uAz0aZZLg==
+  dependencies:
+    "@typescript-eslint/tsconfig-utils" "^8.59.4"
+    "@typescript-eslint/types" "^8.59.4"
+    debug "^4.4.3"
+
 "@typescript-eslint/scope-manager@8.59.1":
   version "8.59.1"
   resolved "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.1.tgz#ed90d054fc3db2d0c81464db3a953a94fb85bb58"
@@ -890,10 +899,23 @@
     "@typescript-eslint/types" "8.59.1"
     "@typescript-eslint/visitor-keys" "8.59.1"
 
+"@typescript-eslint/scope-manager@8.59.4":
+  version "8.59.4"
+  resolved "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.4.tgz#507d1258c758147dac1adee9517a205a8ac1e046"
+  integrity sha512-mUeR/3H1WrTAddJrwut8OoPjfauaztMQmRwV5fQTUyNVJCLiUXXe4lGEyYIL2oFDpP7UtgbGJXCt72wT0z2S3Q==
+  dependencies:
+    "@typescript-eslint/types" "8.59.4"
+    "@typescript-eslint/visitor-keys" "8.59.4"
+
 "@typescript-eslint/tsconfig-utils@8.59.1", "@typescript-eslint/tsconfig-utils@^8.59.1":
   version "8.59.1"
   resolved "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.1.tgz#ba2a779a444f1d5cb92a606f9b209d239fd4cab1"
   integrity sha512-/0nEyPbX7gRsk0Uwfe4ALwwgxuA66d/l2mhRDNlAvaj4U3juhUtJNq0DsY8M2AYwwb9rEq2hrC3IcIcEt++iJA==
+
+"@typescript-eslint/tsconfig-utils@8.59.4", "@typescript-eslint/tsconfig-utils@^8.59.4":
+  version "8.59.4"
+  resolved "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.4.tgz#218ba229d96dde35212e3a76a7d0a6bc831398be"
+  integrity sha512-DLCpnKgD4alVxTBSKulK+gU1KCqOgUXfDRDXh2mZgzokQKa/70ax93I2uVO3m/LLvIAtWZIFoiifudmIqAxpMA==
 
 "@typescript-eslint/type-utils@8.59.1":
   version "8.59.1"
@@ -911,6 +933,11 @@
   resolved "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.1.tgz#c1d014d3f03a97e0113a8899fc9d4e45a7fb0ca9"
   integrity sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A==
 
+"@typescript-eslint/types@8.59.4", "@typescript-eslint/types@^8.59.4":
+  version "8.59.4"
+  resolved "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.4.tgz#c29d5c21bfbaa8347ddc677d3ac1fcd2db0f848e"
+  integrity sha512-F1o7WJcCq+bc8dwcO/YsSEOudAH8RDtaOhM6wcAQhcUsFhnWQl81JKy48q1hoxAU0qrzM89+31GYh1515Zde3Q==
+
 "@typescript-eslint/typescript-estree@8.59.1":
   version "8.59.1"
   resolved "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.1.tgz#4391fadf98a22c869c5b6522dbf4e491e53e351a"
@@ -920,6 +947,21 @@
     "@typescript-eslint/tsconfig-utils" "8.59.1"
     "@typescript-eslint/types" "8.59.1"
     "@typescript-eslint/visitor-keys" "8.59.1"
+    debug "^4.4.3"
+    minimatch "^10.2.2"
+    semver "^7.7.3"
+    tinyglobby "^0.2.15"
+    ts-api-utils "^2.5.0"
+
+"@typescript-eslint/typescript-estree@8.59.4":
+  version "8.59.4"
+  resolved "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.4.tgz#d005e5e1fb425526f39685594bed34a04ad755ea"
+  integrity sha512-F+RuOmcDXo4+TPdfd/TCLS3m2nw8gE9XXyZLrA3JBfaA5tz9TtdkyD3YJFmPxulyc2cKbEok/CvFE3MgSLWnag==
+  dependencies:
+    "@typescript-eslint/project-service" "8.59.4"
+    "@typescript-eslint/tsconfig-utils" "8.59.4"
+    "@typescript-eslint/types" "8.59.4"
+    "@typescript-eslint/visitor-keys" "8.59.4"
     debug "^4.4.3"
     minimatch "^10.2.2"
     semver "^7.7.3"
@@ -936,12 +978,30 @@
     "@typescript-eslint/types" "8.59.1"
     "@typescript-eslint/typescript-estree" "8.59.1"
 
+"@typescript-eslint/utils@^8.58.2":
+  version "8.59.4"
+  resolved "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.4.tgz#8ccd2b08aecc72c7efc0d7ac6695631d199d256e"
+  integrity sha512-cYXeNAUsG4lJo5dbc1FcKm+JwIWrj1/UpTORsC6tGMjEZ81DYcvIr9/ueikhMa/Y/gDQYGp+YX9/xQrXje5BJw==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.9.1"
+    "@typescript-eslint/scope-manager" "8.59.4"
+    "@typescript-eslint/types" "8.59.4"
+    "@typescript-eslint/typescript-estree" "8.59.4"
+
 "@typescript-eslint/visitor-keys@8.59.1":
   version "8.59.1"
   resolved "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.1.tgz#b5cba576287a3eeb0b400b62813189abcc3f976a"
   integrity sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg==
   dependencies:
     "@typescript-eslint/types" "8.59.1"
+    eslint-visitor-keys "^5.0.0"
+
+"@typescript-eslint/visitor-keys@8.59.4":
+  version "8.59.4"
+  resolved "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.4.tgz#1ac23b747b011f5cbdb449da97769f6c5f3a9355"
+  integrity sha512-U3gxVaDVnuZKhSspW/MzMxE1kq7zOdc072FcSNoqA1I9p8HyKbBFfEHoWckBAMgNMph4MamwS5iTVzFmrnt8TQ==
+  dependencies:
+    "@typescript-eslint/types" "8.59.4"
     eslint-visitor-keys "^5.0.0"
 
 "@yarnpkg/lockfile@^1.1.0":
@@ -982,7 +1042,7 @@ abbrev@^4.0.0:
   resolved "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz#ec933f0e27b6cd60e89b5c6b2a304af42209bb05"
   integrity sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==
 
-acorn-jsx@^5.2.0, acorn-jsx@^5.3.2:
+acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
@@ -993,11 +1053,6 @@ acorn-walk@^8.1.1:
   integrity sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==
   dependencies:
     acorn "^8.11.0"
-
-acorn@^7.1.1:
-  version "7.4.1"
-  resolved "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
-  integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
 acorn@^8.11.0, acorn@^8.4.1:
   version "8.14.1"
@@ -1731,6 +1786,14 @@ eslint-config-prettier@^10.1.8:
   resolved "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz#15734ce4af8c2778cc32f0b01b37b0b5cd1ecb97"
   integrity sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==
 
+eslint-plugin-perfectionist@^5.9.0:
+  version "5.9.0"
+  resolved "https://registry.npmjs.org/eslint-plugin-perfectionist/-/eslint-plugin-perfectionist-5.9.0.tgz#d8844892fa4b1069df27910f41d7e7981df1ca4b"
+  integrity sha512-8TWzg02zmnBdZwCkWLi8jhzqXI+fE7Z/RwV8SL6xD45tJ8Bp3wGuYL2XtQgfe/Wd0eBqOUX+s6ey73IyszvKTA==
+  dependencies:
+    "@typescript-eslint/utils" "^8.58.2"
+    natural-orderby "^5.0.0"
+
 eslint-plugin-prettier@^5.5.5:
   version "5.5.5"
   resolved "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.5.tgz#9eae11593faa108859c26f9a9c367d619a0769c0"
@@ -1738,16 +1801,6 @@ eslint-plugin-prettier@^5.5.5:
   dependencies:
     prettier-linter-helpers "^1.0.1"
     synckit "^0.11.12"
-
-eslint-plugin-sort-keys-fix@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.npmjs.org/eslint-plugin-sort-keys-fix/-/eslint-plugin-sort-keys-fix-1.1.2.tgz#00c8b5791612ec32162b8d7a0563e9c6eb27ec59"
-  integrity sha512-DNPHFGCA0/hZIsfODbeLZqaGY/+q3vgtshF85r+YWDNCQ2apd9PNs/zL6ttKm0nD1IFwvxyg3YOTI7FHl4unrw==
-  dependencies:
-    espree "^6.1.2"
-    esutils "^2.0.2"
-    natural-compare "^1.4.0"
-    requireindex "~1.2.0"
 
 eslint-scope@^9.1.2:
   version "9.1.2"
@@ -1758,11 +1811,6 @@ eslint-scope@^9.1.2:
     "@types/estree" "^1.0.8"
     esrecurse "^4.3.0"
     estraverse "^5.2.0"
-
-eslint-visitor-keys@^1.1.0:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
-  integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
 
 eslint-visitor-keys@^3.4.3:
   version "3.4.3"
@@ -1832,15 +1880,6 @@ espree@^11.2.0:
     acorn "^8.16.0"
     acorn-jsx "^5.3.2"
     eslint-visitor-keys "^5.0.1"
-
-espree@^6.1.2:
-  version "6.2.1"
-  resolved "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz#77fc72e1fd744a2052c20f38a5b575832e82734a"
-  integrity sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==
-  dependencies:
-    acorn "^7.1.1"
-    acorn-jsx "^5.2.0"
-    eslint-visitor-keys "^1.1.0"
 
 esprima@^4.0.0:
   version "4.0.1"
@@ -3042,6 +3081,11 @@ natural-compare@^1.4.0:
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
+natural-orderby@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/natural-orderby/-/natural-orderby-5.0.0.tgz#bb655f669ee9c84e82cdc6cddbba25eb263cd9f4"
+  integrity sha512-kKHJhxwpR/Okycz4HhQKKlhWe4ASEfPgkSWNmKFHd7+ezuQlxkA5cM3+XkBPvm1gmHen3w53qsYAv+8GwRrBlg==
+
 negotiator@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz#b6c91bb47172d69f93cfd7c357bbb529019b5f6a"
@@ -3771,11 +3815,6 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
-
-requireindex@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz#3463cdb22ee151902635aa6c9535d4de9c2ef1ef"
-  integrity sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==
 
 resolve-cwd@^3.0.0:
   version "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -776,6 +776,18 @@
   resolved "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.41.tgz#aa51a6c1946df2c5a11494a2cdb9318e026db16c"
   integrity sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g==
 
+"@stylistic/eslint-plugin@^5.10.0":
+  version "5.10.0"
+  resolved "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.10.0.tgz#471bbd9f7a27ceaac4a217e7f5b3890855e5640c"
+  integrity sha512-nPK52ZHvot8Ju/0A4ucSX1dcPV2/1clx0kLcH5wDmrE4naKso7TUC/voUyU1O9OTKTrR6MYip6LP0ogEMQ9jPQ==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.9.1"
+    "@typescript-eslint/types" "^8.56.0"
+    eslint-visitor-keys "^4.2.1"
+    espree "^10.4.0"
+    estraverse "^5.3.0"
+    picomatch "^4.0.3"
+
 "@tsconfig/node10@^1.0.7":
   version "1.0.11"
   resolved "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz#6ee46400685f130e278128c7b38b7e031ff5b2f2"
@@ -933,7 +945,7 @@
   resolved "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.1.tgz#c1d014d3f03a97e0113a8899fc9d4e45a7fb0ca9"
   integrity sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A==
 
-"@typescript-eslint/types@8.59.4", "@typescript-eslint/types@^8.59.4":
+"@typescript-eslint/types@8.59.4", "@typescript-eslint/types@^8.56.0", "@typescript-eslint/types@^8.59.4":
   version "8.59.4"
   resolved "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.4.tgz#c29d5c21bfbaa8347ddc677d3ac1fcd2db0f848e"
   integrity sha512-F1o7WJcCq+bc8dwcO/YsSEOudAH8RDtaOhM6wcAQhcUsFhnWQl81JKy48q1hoxAU0qrzM89+31GYh1515Zde3Q==
@@ -1863,7 +1875,7 @@ eslint@^10.0.2:
     natural-compare "^1.4.0"
     optionator "^0.9.3"
 
-espree@^10.0.1:
+espree@^10.0.1, espree@^10.4.0:
   version "10.4.0"
   resolved "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz#d54f4949d4629005a1fa168d937c3ff1f7e2a837"
   integrity sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==
@@ -1900,7 +1912,7 @@ esrecurse@^4.3.0:
   dependencies:
     estraverse "^5.2.0"
 
-estraverse@^5.1.0, estraverse@^5.2.0:
+estraverse@^5.1.0, estraverse@^5.2.0, estraverse@^5.3.0:
   version "5.3.0"
   resolved "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==


### PR DESCRIPTION
## Summary

`eslint-plugin-sort-keys-fix` is abandoned — `1.1.2` is the latest release and it was last published in **June 2023**, before ESLint 9's flat-config API changes. It calls the removed `context.getSourceCode()` and throws:

```
TypeError: context.getSourceCode is not a function
  Rule: "sort-keys-fix/sort-keys-fix"
```

under **ESLint 10** whenever the rule has a key to reorder. This makes `sort-keys-fix/sort-keys-fix` unusable for any consumer on ESLint 10 — they have to disable the rule to lint at all.

## Change

Replace it with the maintained [`eslint-plugin-perfectionist`](https://perfectionist.dev) and its `sort-objects` rule, configured to mirror the previous behavior:

| sort-keys-fix | perfectionist/sort-objects |
| --- | --- |
| `'asc'` | `order: 'asc'` |
| `natural: true` | `type: 'natural'` |
| `caseSensitive: true` | `ignoreCase: false` |

Kept as a `warn` with autofix, matching the prior setup.

## Verification

Under ESLint 10, linting an out-of-order object now reports and autofixes cleanly (no crash):

```
3:3  warning  Expected "apple" to come before "banana"  perfectionist/sort-objects
```

`--fix` reorders `banana, apple, cherry` → `apple, banana, cherry`.

## Note for consumers

Consumers pinning `@tstv/eslint-config@^4.x` will pick this up on the next published release and can then drop any `'sort-keys-fix/sort-keys-fix': 'off'` workarounds.