### PR TITLE
feat(tsconfig-common)!: modernize base tsconfig for TS 5.8+ and Node 20+

### DIFF
--- a/packages/tsconfig-common/tsconfig.json
+++ b/packages/tsconfig-common/tsconfig.json
@@ -1,20 +1,18 @@
 {
   "compilerOptions": {
     "allowJs": true,
-    "allowSyntheticDefaultImports": true,
     "declaration": true,
-    "emitDecoratorMetadata": true,
+    "declarationMap": true,
     "erasableSyntaxOnly": true,
     "esModuleInterop": true,
-    "experimentalDecorators": true,
-    "forceConsistentCasingInFileNames": true,
-    "lib": ["es2023"],
-    "module": "Node18",
+    "libReplacement": false,
+    "module": "node20",
     "noEmitOnError": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,
     "noImplicitReturns": true,
     "noUncheckedIndexedAccess": true,
+    "noUncheckedSideEffectImports": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "removeComments": true,
@@ -22,7 +20,8 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
-    "target": "es2022"
+    "target": "es2023",
+    "verbatimModuleSyntax": true
   },
   "display": "Common",
   "exclude": ["${configDir}/coverage", "${configDir}/dist", "${configDir}/docs", "${configDir}/node_modules"]


### PR DESCRIPTION
Modernizes the base `tsconfig.json` of `@tstv/tsconfig-common`.

## Changes

| | Before | After | Why |
|---|---|---|---|
| `module` | `Node18` | `node20` | Node 18 is EOL |
| `target` | `es2022` | `es2023` | matches `node20`'s implied floor |
| `lib` | `["es2023"]` | *(removed)* | redundant at target `es2023` |
| `experimentalDecorators` | `true` | *(removed)* | forces legacy mode; blocks TC39 standard decorators; contradicts `erasableSyntaxOnly` (legacy decorators are non-erasable syntax) |
| `emitDecoratorMetadata` | `true` | *(removed)* | legacy-only, requires `reflect-metadata` |
| `allowSyntheticDefaultImports` | `true` | *(removed)* | implied by `esModuleInterop` |
| `forceConsistentCasingInFileNames` | `true` | *(removed)* | TS default since 5.0 |
| `verbatimModuleSyntax` | — | `true` | modern ESM flag; completes the type-stripping-safe pairing with `erasableSyntaxOnly` |
| `noUncheckedSideEffectImports` | — | `true` | TS 5.6, consistent with the existing strictness flags |
| `declarationMap` | — | `true` | go-to-source for library consumers |
| `libReplacement` | — | `false` | TS 5.9+, skips `@typescript/lib-*` probing |

## Breaking changes (semver-major, suggest v4.0.0)

- Requires TypeScript >= 5.8 (`module: node20`)
- Legacy decorator users (NestJS/TypeORM-style) must re-add `experimentalDecorators`/`emitDecoratorMetadata` in their own config
- `verbatimModuleSyntax` errors on type-only imports written without `import type`

## Out of scope (deliberate)

- `tsconfig-commonjs.json` — standalone legacy CJS variant, its own modernization project
- `tsconfig-react.json` `jsx: "react"` → `"react-jsx"` — separate breaking decision

## Verified

Both package smoke tests pass with TS 6.0.3 (`tsc -p tsconfig.json --noEmit --types node` and the react variant) — the fixture files exercise JSON import attributes, inline `type` imports, and top-level `await`.